### PR TITLE
Basic Thread support

### DIFF
--- a/harbour-sailslack.pro
+++ b/harbour-sailslack.pro
@@ -112,6 +112,7 @@ DISTFILES += \
     data/emoji.json \
     qml/pages/TeamList.qml \
     qml/pages/TeamList.js \
+    qml/pages/Thread.qml \
     qml/pages/UserView.qml
 
 RESOURCES += \

--- a/qml/pages/MessageListItem.qml
+++ b/qml/pages/MessageListItem.qml
@@ -12,9 +12,11 @@ ListItem {
             onClicked: showUserDetails(user.id)
         }
         MenuItem {
-            visible: !item.parent.thread
+            visible: !page.threadId
             text: qsTr("Reply in thread")
-            onClicked: openThread(timestamp)
+            onClicked: {
+                openThread(timestamp)
+            }
         }
     }
 

--- a/qml/pages/MessageListItem.qml
+++ b/qml/pages/MessageListItem.qml
@@ -4,11 +4,17 @@ import Sailfish.Silica 1.0
 ListItem {
     id: item
     contentHeight: column.height + Theme.paddingMedium
+    signal openThread(string threadId)
 
     menu: ContextMenu {
         MenuItem {
             text: qsTr("User Details")
             onClicked: showUserDetails(user.id)
+        }
+        MenuItem {
+            visible: !item.parent.thread
+            text: qsTr("Reply in thread")
+            onClicked: openThread(timestamp)
         }
     }
 
@@ -133,4 +139,5 @@ ListItem {
     function showUserDetails(userId) {
         pageStack.push(Qt.resolvedUrl("UserView.qml"), {"slackClient": slackClient, "userId": userId})
     }
+
 }

--- a/qml/pages/MessageListItem.qml
+++ b/qml/pages/MessageListItem.qml
@@ -8,15 +8,15 @@ ListItem {
 
     menu: ContextMenu {
         MenuItem {
-            text: qsTr("User Details")
-            onClicked: showUserDetails(user.id)
-        }
-        MenuItem {
             visible: !page.threadId
             text: qsTr("Reply in thread")
             onClicked: {
                 openThread(timestamp)
             }
+        }
+        MenuItem {
+            text: qsTr("User Details")
+            onClicked: showUserDetails(user.id)
         }
     }
 
@@ -64,17 +64,9 @@ ListItem {
             visible: reply_count > 0
 
             Label {
-                id: replies
-                text: qsTr("Replies")
+                text: qsTr("Replies: %1").arg(reply_count)
                 anchors.left: parent.left
                 font.italic: true
-                font.pixelSize: Theme.fontSizeTiny
-                color: infoColor
-            }
-
-            Label {
-                text: " : " + String(reply_count)
-                anchors.left: replies.right
                 font.pixelSize: Theme.fontSizeTiny
                 color: infoColor
             }

--- a/qml/pages/MessageListItem.qml
+++ b/qml/pages/MessageListItem.qml
@@ -50,6 +50,28 @@ ListItem {
             onLinkActivated: handleLink(link)
         }
 
+        Item {
+            width: parent.width
+            height: childrenRect.height
+            visible: reply_count > 0
+
+            Label {
+                id: replies
+                text: qsTr("Replies")
+                anchors.left: parent.left
+                font.italic: true
+                font.pixelSize: Theme.fontSizeTiny
+                color: infoColor
+            }
+
+            Label {
+                text: " : " + String(reply_count)
+                anchors.left: replies.right
+                font.pixelSize: Theme.fontSizeTiny
+                color: infoColor
+            }
+        }
+
         Spacer {
             height: Theme.paddingMedium
             visible: contentLabel.visible && (imageRepeater.count > 0 || attachmentRepeater.count > 0)

--- a/qml/pages/MessageListView.qml
+++ b/qml/pages/MessageListView.qml
@@ -79,7 +79,7 @@ SilicaListView {
     }
 
     header: PageHeader {
-        title: thread ? qsTr("Thread in %1%2").arg("#").arg(channel.name) : channel.name
+        title: thread ? qsTr("Thread in #%1").arg(channel.name) : channel.name
     }
 
     model: ListModel {
@@ -233,6 +233,7 @@ SilicaListView {
             }
 
             if (update) {
+                // TODO: better than linear search for message to be updated
                 for (var i = 0; i < messageListModel.count; i++) {
                     if (messageListModel.get(i).timestamp === message.timestamp) {
                         messageListModel.set(i, message);

--- a/qml/pages/MessageListView.qml
+++ b/qml/pages/MessageListView.qml
@@ -79,7 +79,7 @@ SilicaListView {
     }
 
     header: PageHeader {
-        title: getTitle()
+        title: thread ? qsTr("Thread in %1%2").arg("#").arg(channel.name) : channel.name
     }
 
     model: ListModel {
@@ -104,7 +104,7 @@ SilicaListView {
 
     footer: MessageInput {
         visible: inputEnabled
-        placeholder: qsTr("Message %1%2").arg("#").arg(channel.name)
+        placeholder: (thread ? qsTr("Message thread in %1%2") : qsTr("Message %1%2")).arg("#").arg(channel.name)
         onSendMessage: {
             var threadId = thread && thread.thread_ts;
             slackClient.postMessage(channel.id, threadId || "", content)
@@ -147,18 +147,6 @@ SilicaListView {
         slackClient.onLoadMessagesSuccess.disconnect(handleLoadSuccess)
         slackClient.onLoadHistorySuccess.disconnect(handleHistorySuccess)
         slackClient.onMessageReceived.disconnect(handleMessageReceived)
-    }
-
-    function getTitle() {
-        var result = "Thread";
-        if (thread) {
-            if (thread.content) {
-                result = thread.content;
-            }
-        } else {
-            result = channel.name;
-        }
-        return result;
     }
 
     function markLatest() {

--- a/qml/pages/Thread.qml
+++ b/qml/pages/Thread.qml
@@ -1,0 +1,67 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import harbour.sailslack 1.0
+
+Page {
+    id: page
+
+    property Client slackClient
+
+    property string channelId
+    property variant channel
+    property string threadId
+    property variant thread
+    property bool initialized: false
+
+    SilicaFlickable {
+        anchors.fill: parent
+
+        BusyIndicator {
+            id: loader
+            visible: true
+            running: visible
+            size: BusyIndicatorSize.Large
+            anchors.centerIn: parent
+        }
+
+        MessageListView {
+            id: listView
+            thread: page.thread
+            channel: page.channel
+            anchors.fill: parent
+            slackClient: page.slackClient
+
+            onLoadCompleted: {
+                loader.visible = false
+            }
+
+            onLoadStarted: {
+                loader.visible = true
+            }
+        }
+    }
+
+    ConnectionPanel {
+        slackClient: parent.slackClient
+    }
+
+    Component.onCompleted: {
+        page.channel = slackClient.getChannel(page.channelId)
+        page.thread = slackClient.getThread(page.threadId)
+    }
+
+    onStatusChanged: {
+        if (status === PageStatus.Active) {
+            slackClient.setActiveWindow(page.threadId)
+
+            if (!initialized) {
+                initialized = true
+                listView.loadMessages()
+            }
+        }
+        else if (status === PageStatus.Deactivating) {
+            slackClient.setActiveWindow("")
+            listView.markLatest()
+        }
+    }
+}

--- a/src/slackclient.h
+++ b/src/slackclient.h
@@ -111,6 +111,7 @@ public slots:
     void loadHistory(QString channelId, QString latest);
     void loadMessages(QString channelId);
     void handleLoadMessagesReply();
+    bool createThread(QString channelId, QString threadId);
 
     void loadThreadMessages(QString threadId, QString channelId);
 

--- a/src/slackclient.h
+++ b/src/slackclient.h
@@ -43,7 +43,9 @@ public:
     Q_INVOKABLE void setActiveWindow(QString windowId);
 
     Q_INVOKABLE QVariantList getChannels();
-    Q_INVOKABLE QVariant getChannel(QString channelId);
+    Q_INVOKABLE QVariant getChannel(const QString& channelId);
+
+    Q_INVOKABLE QVariant getThread(const QString& threadId);
 
     SlackClientConfig *getConfig() const { return this->config; }
     bool getInitialized() const { return initialized; }
@@ -66,7 +68,7 @@ signals:
     void loadUsersSuccess();
     void loadUsersFail();
 
-    void loadMessagesSuccess(QString channelId, QVariantList messages, bool hasMore);
+    void loadMessagesSuccess(QString channelId, QString threadId, QVariantList messages, bool hasMore);
     void loadMessagesFail();
     void loadHistorySuccess(QString channelId, QVariantList messages, bool hasMore);
     void loadHistoryFail();
@@ -84,7 +86,7 @@ signals:
     void updateChannelUnreadCountFailed(QString);
     void updateImUnreadCountFailed(QString);
 
-    void messageReceived(QVariantMap message);
+    void messageReceived(QVariantMap message, bool update);
     void channelUpdated(QVariantMap channel);
     void channelJoined(QVariantMap channel);
     void channelLeft(QVariantMap channel);
@@ -110,15 +112,17 @@ public slots:
     void loadMessages(QString channelId);
     void handleLoadMessagesReply();
 
+    void loadThreadMessages(QString threadId, QString channelId);
+
     void logout();
     void loadUsers(const QString &cursor = {});
     void markChannel(QString channelId, QString time);
-    void joinChannel(QString channelId);
+    void joinChannel(const QString& channelId);
     void leaveChannel(QString channelId);
     void leaveGroup(QString groupId);
     void openChat(QString chatId);
     void closeChat(QString chatId);
-    void postMessage(QString channelId, QString content);
+    void postMessage(QString channelId, QString threadId, QString content);
     void postImage(QString channelId, QString imagePath, QString title, QString comment);
     void loadUserInfo(QString userId);
 
@@ -147,7 +151,7 @@ private:
 
     void loadConversations(QString cursor = QString());
 
-    void parseMessageUpdate(QJsonObject message);
+    void parseMessageUpdate(QJsonObject message, bool update = false);
     void parseChannelUpdate(QJsonObject message);
     void parseChannelJoin(QJsonObject message);
     void parseChannelLeft(QJsonObject message);

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -54,7 +54,7 @@ QString messageThread(const QVariantMap& message) {
 }
 
 bool isThreadStarter(const QVariantMap& message) {
-    return message.value("thread_ts") == message.value("timestamp");
+    return message.value("thread_ts") == message.value("timestamp") || message.value("transient").toBool();
 }
 
 void Storage::setChannelMessages(const QString &channelId, QVariantList messages) {
@@ -78,6 +78,8 @@ void Storage::createOrUpdateThread(const QString &threadId, QVariantMap message)
         threadMap.insert(threadId, message);
     } else {
         qDebug() << "Thread already exists:" << threadId;
+        threadMap.insert(threadId, message);
+        threadMessageMap.value(threadId).toList().replace(0, message);
     }
 
     // Search the starting message in its channel

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -1,13 +1,14 @@
 #include "storage.h"
 
 #include <QDebug>
+#include <QSequentialIterable>
 
 void Storage::saveUser(QVariantMap user) {
     userMap.insert(user.value("id").toString(), user);
 }
 
-QVariantMap Storage::user(QVariant id) {
-    return userMap.value(id.toString()).toMap();
+QVariantMap Storage::user(const QString &id) {
+    return userMap.value(id).toMap();
 }
 
 QVariantList Storage::users() {
@@ -18,44 +19,122 @@ void Storage::saveChannel(QVariantMap channel) {
     channelMap.insert(channel.value("id").toString(), channel);
 }
 
-QVariantMap Storage::channel(QVariant id) {
-    return channelMap.value(id.toString()).toMap();
+QVariantMap Storage::channel(const QString &id) {
+    return channelMap.value(id).toMap();
+}
+
+QVariantMap Storage::thread(const QString &id) {
+    return threadMap.value(id).toMap();
 }
 
 QVariantList Storage::channels() {
     return channelMap.values();
 }
 
-QVariantList Storage::channelMessages(QVariant channelId) {
-    return channelMessageMap.value(channelId.toString()).toList();
+QVariantList Storage::channelMessages(const QString &channelId) {
+    return channelMessageMap.value(channelId).toList();
 }
 
-bool Storage::channelMessagesExist(QVariant channelId) {
-    return channelMessageMap.contains(channelId.toString());
+bool Storage::channelMessagesExist(const QString &channelId) {
+    return channelMessageMap.contains(channelId);
 }
 
-void Storage::setChannelMessages(QVariant channelId, QVariantList messages) {
-    channelMessageMap.insert(channelId.toString(), messages);
+QVariantList Storage::threadMessages(const QString &threadId) {
+    return threadMessageMap.value(threadId).toList();
 }
 
-void Storage::prependChannelMessages(QVariant channelId, QVariantList messages) {
+bool Storage::threadMessagesExist(const QString &threadId) {
+    return channelMessageMap.contains(threadId);
+}
+
+QString messageThread(const QVariantMap& message) {
+    return message.contains("thread_ts")
+            ? message.value("thread_ts").toString()
+            : QString();
+}
+
+bool isThreadStarter(const QVariantMap& message) {
+    return message.value("thread_ts") == message.value("timestamp");
+}
+
+void Storage::setChannelMessages(const QString &channelId, QVariantList messages) {
+    channelMessageMap.insert(channelId, messages);
+    for (auto &message: messages) {
+        auto threadId = messageThread(message.toMap());
+        if (!threadId.isEmpty()) {
+            createOrUpdateThread(threadId, message.toMap());
+        }
+    }
+}
+
+void Storage::setThreadMessages(const QString& threadId, QVariantList messages) {
+    threadMessageMap.insert(threadId, messages);
+}
+
+void Storage::createOrUpdateThread(const QString &threadId, QVariantMap message) {
+    Q_ASSERT(isThreadStarter(message));
+    if (!threadMap.contains(threadId)) {
+        threadMessageMap.insert(threadId, QVariantList({message}));
+        threadMap.insert(threadId, message);
+    } else {
+        qDebug() << "Thread already exists:" << threadId;
+    }
+
+    // Search the starting message in its channel
+    // (or better do this from JS)
+}
+
+void Storage::prependChannelMessages(const QString &channelId, QVariantList messages) {
     QVariantList existing = channelMessages(channelId);
     messages.append(existing);
     setChannelMessages(channelId, messages);
 }
 
-void Storage::appendChannelMessage(QVariant channelId, QVariantMap message) {
+bool Storage::appendChannelMessage(const QString &channelId, QVariantMap message) {
+    bool result = false;
     QVariantList messages = channelMessages(channelId);
-    messages.append(message);
-    setChannelMessages(channelId, messages);
+    auto threadId = messageThread(message);
+    if (threadId.isEmpty() || isThreadStarter(message)) {
+        messages.append(message);
+        setChannelMessages(channelId, messages);
+        result = true;
+    }
+    if (!threadId.isEmpty()) {
+        appendThreadMessage(threadId, message);
+    }
+
+    return result;
 }
 
 void Storage::clearChannelMessages() {
     channelMessageMap.clear();
 }
 
+void Storage::appendThreadMessage(const QString &threadId, QVariantMap message) {
+    if(isThreadStarter(message)) {
+        createOrUpdateThread(threadId, message);
+    }
+
+    auto messages = threadMessageMap.value(threadId).toList();
+    if (messages.size()) {
+        if (isThreadStarter(message)) {
+            qDebug() << "Updated thread starter for:" << threadId;
+        } else {
+            messages.push_back(message);
+        }
+    } else {
+        qDebug("Thread without thread starter?");
+        Q_ASSERT(false);
+        return;
+    }
+
+    setThreadMessages(threadId, messages);
+}
+
 void Storage::clear() {
     userMap.clear();
     channelMap.clear();
     channelMessageMap.clear();
+    threadMap.clear();
+    threadMessageMap.clear();
 }

--- a/src/storage.h
+++ b/src/storage.h
@@ -18,6 +18,7 @@ public:
     QVariantList channelMessages(const QString &channelId);
     bool channelMessagesExist(const QString &channelId);
     void setChannelMessages(const QString &channelId, QVariantList messages);
+    QVariantList::const_iterator findSortedMessages(const QVariantList& messages, const QString& timestamp);
 
     QVariantList threadMessages(const QString &threadId);
     bool threadMessagesExist(const QString &threadId);
@@ -25,7 +26,7 @@ public:
     void createOrUpdateThread(const QString &threadId, QVariantMap message);
 
     void prependChannelMessages(const QString &channelId, QVariantList messages);
-    bool appendChannelMessage(const QString &channelId, QVariantMap message);
+    void appendChannelMessage(const QString &channelId, QVariantMap message);
     void clearChannelMessages();
 
     void appendThreadMessage(const QString &threadId, QVariantMap message);

--- a/src/storage.h
+++ b/src/storage.h
@@ -6,27 +6,39 @@
 class Storage
 {
 public:
-    QVariantMap user(QVariant id);
+    QVariantMap user(const QString &id);
     QVariantList users();
     void saveUser(QVariantMap user);
 
-    QVariantMap channel(QVariant id);
+    QVariantMap channel(const QString &id);
+    QVariantMap thread(const QString &id);
     QVariantList channels();
     void saveChannel(QVariantMap channel);
 
-    QVariantList channelMessages(QVariant channelId);
-    bool channelMessagesExist(QVariant channelId);
-    void setChannelMessages(QVariant channelId, QVariantList messages);
-    void prependChannelMessages(QVariant channelId, QVariantList messages);
-    void appendChannelMessage(QVariant channelId, QVariantMap message);
+    QVariantList channelMessages(const QString &channelId);
+    bool channelMessagesExist(const QString &channelId);
+    void setChannelMessages(const QString &channelId, QVariantList messages);
+
+    QVariantList threadMessages(const QString &threadId);
+    bool threadMessagesExist(const QString &threadId);
+    void setThreadMessages(const QString& threadId, QVariantList messages);
+    void createOrUpdateThread(const QString &threadId, QVariantMap message);
+
+    void prependChannelMessages(const QString &channelId, QVariantList messages);
+    bool appendChannelMessage(const QString &channelId, QVariantMap message);
     void clearChannelMessages();
+
+    void appendThreadMessage(const QString &threadId, QVariantMap message);
 
     void clear();
 
 private:
+
     QVariantMap userMap;
     QVariantMap channelMap;
     QVariantMap channelMessageMap;
+    QVariantMap threadMap;
+    QVariantMap threadMessageMap;
 };
 
 #endif // STORAGE_H

--- a/src/teamsmodel.cpp
+++ b/src/teamsmodel.cpp
@@ -1,6 +1,7 @@
 #include "teamsmodel.h"
 
 #include <QQmlEngine>
+#include <functional>
 
 #include <functional>
 

--- a/translations/harbour-sailslack-bg.ts
+++ b/translations/harbour-sailslack-bg.ts
@@ -226,38 +226,58 @@ Are you sure you wish to leave?</source>
 <context>
     <name>MessageListItem</name>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="10"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="18"/>
         <source>User Details</source>
         <translation>Данни на потребителя</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListItem.qml" line="67"/>
+        <source>Replies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListItem.qml" line="12"/>
+        <source>Reply in thread</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MessageListView</name>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="38"/>
+        <location filename="../qml/pages/MessageListView.qml" line="39"/>
         <source>User Details</source>
         <translation>Данни на потребителя</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="100"/>
+        <location filename="../qml/pages/MessageListView.qml" line="82"/>
+        <source>Thread in #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListView.qml" line="112"/>
         <source>Message %1%2</source>
         <translation>Съобщение %1%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListView.qml" line="112"/>
+        <source>Message thread in %1%2</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SlackClient</name>
     <message>
-        <location filename="../src/slackclient.cpp" line="320"/>
+        <location filename="../src/slackclient.cpp" line="338"/>
         <source>in %1 @ %2</source>
         <translation>в %1 @ %2</translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="323"/>
+        <location filename="../src/slackclient.cpp" line="341"/>
         <source>from %1 @ %2</source>
         <translation>от %1 @ %2</translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="326"/>
+        <location filename="../src/slackclient.cpp" line="344"/>
         <source>New message</source>
         <translation>Ново съобщение</translation>
     </message>

--- a/translations/harbour-sailslack-sv.ts
+++ b/translations/harbour-sailslack-sv.ts
@@ -226,38 +226,58 @@ Vill du verkligen lämna?</translation>
 <context>
     <name>MessageListItem</name>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="10"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="18"/>
         <source>User Details</source>
         <translation>Användarinformation</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListItem.qml" line="67"/>
+        <source>Replies: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListItem.qml" line="12"/>
+        <source>Reply in thread</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MessageListView</name>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="38"/>
+        <location filename="../qml/pages/MessageListView.qml" line="39"/>
         <source>User Details</source>
         <translation>Användarinformation</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="100"/>
+        <location filename="../qml/pages/MessageListView.qml" line="82"/>
+        <source>Thread in #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListView.qml" line="112"/>
         <source>Message %1%2</source>
         <translation>Meddelande %1%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListView.qml" line="112"/>
+        <source>Message thread in %1%2</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SlackClient</name>
     <message>
-        <location filename="../src/slackclient.cpp" line="320"/>
+        <location filename="../src/slackclient.cpp" line="338"/>
         <source>in %1 @ %2</source>
         <translation>i %1 @ %2</translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="323"/>
+        <location filename="../src/slackclient.cpp" line="341"/>
         <source>from %1 @ %2</source>
         <translation>från %1 @ %2</translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="326"/>
+        <location filename="../src/slackclient.cpp" line="344"/>
         <source>New message</source>
         <translation>Nytt meddelande</translation>
     </message>

--- a/translations/harbour-sailslack.ts
+++ b/translations/harbour-sailslack.ts
@@ -221,18 +221,18 @@ Are you sure you wish to leave?</source>
 <context>
     <name>MessageListItem</name>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="11"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="18"/>
         <source>User Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="16"/>
-        <source>Reply in thread</source>
+        <location filename="../qml/pages/MessageListItem.qml" line="67"/>
+        <source>Replies: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="68"/>
-        <source>Replies</source>
+        <location filename="../qml/pages/MessageListItem.qml" line="12"/>
+        <source>Reply in thread</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -244,25 +244,35 @@ Are you sure you wish to leave?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="107"/>
+        <location filename="../qml/pages/MessageListView.qml" line="82"/>
+        <source>Thread in #%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListView.qml" line="112"/>
         <source>Message %1%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListView.qml" line="112"/>
+        <source>Message thread in %1%2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SlackClient</name>
     <message>
-        <location filename="../src/slackclient.cpp" line="320"/>
+        <location filename="../src/slackclient.cpp" line="338"/>
         <source>in %1 @ %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="323"/>
+        <location filename="../src/slackclient.cpp" line="341"/>
         <source>from %1 @ %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="326"/>
+        <location filename="../src/slackclient.cpp" line="344"/>
         <source>New message</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailslack.ts
+++ b/translations/harbour-sailslack.ts
@@ -225,16 +225,21 @@ Are you sure you wish to leave?</source>
         <source>User Details</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../qml/pages/MessageListItem.qml" line="60"/>
+        <source>Replies</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MessageListView</name>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="38"/>
+        <location filename="../qml/pages/MessageListView.qml" line="39"/>
         <source>User Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="100"/>
+        <location filename="../qml/pages/MessageListView.qml" line="107"/>
         <source>Message %1%2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailslack.ts
+++ b/translations/harbour-sailslack.ts
@@ -221,12 +221,17 @@ Are you sure you wish to leave?</source>
 <context>
     <name>MessageListItem</name>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="10"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="11"/>
         <source>User Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="60"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="16"/>
+        <source>Reply in thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListItem.qml" line="68"/>
         <source>Replies</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
This is basic thread support based on `thread_ts == timestamp` being the criteria for a 'thread starter' message.
When a new message with `thread_ts != timesptamp` is received it goes into a separate `storage.threadMap/threadMessageMap`.
You can start a thread by long clicking on a message. The not-yet-existing thread is marked as 'transient' until an actual reply gets in / is sent.
You can view a thread by clicking on a message that has "replies: x" underneath.

This PR includes basic message updated support (so it does not append the message).