### PR TITLE
Channel/Chats improvements

### DIFF
--- a/qml/pages/ChannelList.js
+++ b/qml/pages/ChannelList.js
@@ -64,9 +64,6 @@ function compareChannels(a, b) {
     result = compareByBool(a, b, "is_private", false);
     if (result) return result;
 
-    result = compareByBool(a, b, "is_mpim", true);
-    if (result) return result;
-
     return Channel.compareByName(a, b)
 }
 

--- a/qml/pages/ChannelList.js
+++ b/qml/pages/ChannelList.js
@@ -46,8 +46,8 @@ function handleChannelLeft(channel) {
 }
 
 function getChannelSection(channel) {
-    if (channel.unreadCount > 0) {
-        return "unread"
+    if (channel.is_starred > 0) {
+        return "starred"
     }
     else {
         return channel.category
@@ -55,38 +55,34 @@ function getChannelSection(channel) {
 }
 
 function compareChannels(a, b) {
-    if (a.unreadCount === 0 && b.unreadCount === 0) {
-        return compareByCategory(a, b)
-    }
-    else {
-        if (a.unreadCount > 0 && b.unreadCount > 0) {
-            return Channel.compareByName(a, b)
-        }
-        else if (a.unreadCount > 0) {
-            return -1
-        }
-        else if (b.unreadCount > 0) {
-            return 1
-        }
-        else {
-            return Channel.compareByName(a, b)
-        }
-    }
+    var result = compareByBool(a, b, "is_starred", true);
+    if (result) return result;
+
+    result = compareByCategory(a, b);
+    if (result) return result;
+
+    result = compareByBool(a, b, "is_private", false);
+    if (result) return result;
+
+    return Channel.compareByName(a, b)
 }
 
+var categories = ["starred", "channels", "chat"];
 function compareByCategory(a, b) {
-    if (a.category === b.category) {
-        return Channel.compareByName(a, b)
+    if (a.category !== b.category) {
+        var diff = categories.indexOf(a.category) - categories.indexOf(b.category);
+        return diff / Math.abs(diff);
     }
-    else {
-        if (a.category === "channel") {
-            return -1
-        }
-        else if (b.category === "channel") {
-            return 1
-        }
-        else {
-            return Channel.compareByName(a, b)
+    return 0;
+}
+
+function compareByBool(a, b, prop, desired) {
+    if (a[prop] !== b[prop]) {
+        if (b[prop] === desired) {
+            return 1;
+        } else {
+            return -1;
         }
     }
+    return 0;
 }

--- a/qml/pages/ChannelList.js
+++ b/qml/pages/ChannelList.js
@@ -70,7 +70,7 @@ function compareChannels(a, b) {
     return Channel.compareByName(a, b)
 }
 
-var categories = ["starred", "channels", "chat"];
+var categories = ["starred", "channel", "chat"];
 function compareByCategory(a, b) {
     if (a.category !== b.category) {
         var diff = categories.indexOf(a.category) - categories.indexOf(b.category);
@@ -81,9 +81,9 @@ function compareByCategory(a, b) {
 
 function compareByBool(a, b, prop, desired) {
     if (a[prop] !== b[prop]) {
-        if (b[prop] === desired) {
+        if (Boolean(b[prop]) === desired) {
             return 1;
-        } else {
+        } else if (Boolean(a[prop]) === desired){
             return -1;
         }
     }

--- a/qml/pages/ChannelList.js
+++ b/qml/pages/ChannelList.js
@@ -64,6 +64,9 @@ function compareChannels(a, b) {
     result = compareByBool(a, b, "is_private", false);
     if (result) return result;
 
+    result = compareByBool(a, b, "is_mpim", true);
+    if (result) return result;
+
     return Channel.compareByName(a, b)
 }
 

--- a/qml/pages/ChannelList.js
+++ b/qml/pages/ChannelList.js
@@ -46,7 +46,7 @@ function handleChannelLeft(channel) {
 }
 
 function getChannelSection(channel) {
-    if (channel.is_starred > 0) {
+    if (channel.is_starred) {
         return "starred"
     }
     else {
@@ -55,19 +55,25 @@ function getChannelSection(channel) {
 }
 
 function compareChannels(a, b) {
-    var result = compareByBool(a, b, "is_starred", true);
-    if (result) return result;
+    var result = 0;
+    if (b.unreadCount !== a.unreadCount) {
+        result = (b.unreadCount ? 1 : 0) - (a.unreadCount ? 1 : 0);
+    }
+    if (result !== 0) return result;
+
+    result = compareByBool(a, b, "is_starred", true);
+    if (result !== 0) return result;
 
     result = compareByCategory(a, b);
-    if (result) return result;
+    if (result !== 0) return result;
 
     result = compareByBool(a, b, "is_private", false);
-    if (result) return result;
+    if (result !== 0) return result;
 
     return Channel.compareByName(a, b)
 }
 
-var categories = ["starred", "channel", "chat"];
+var categories = ["channel", "chat"];
 function compareByCategory(a, b) {
     if (a.category !== b.category) {
         var diff = categories.indexOf(a.category) - categories.indexOf(b.category);

--- a/qml/pages/ChannelListView.qml
+++ b/qml/pages/ChannelListView.qml
@@ -102,6 +102,8 @@ SilicaListView {
 
     function getSectionName(section) {
         switch (section) {
+            case "unread":
+                return qsTr("Unread");
             case "starred":
                 return qsTr("Starred")
 

--- a/qml/pages/ChannelListView.qml
+++ b/qml/pages/ChannelListView.qml
@@ -102,8 +102,8 @@ SilicaListView {
 
     function getSectionName(section) {
         switch (section) {
-            case "unread":
-                return qsTr("Unreads")
+            case "starred":
+                return qsTr("Starred")
 
             case "channel":
                 return qsTr("Channels")

--- a/qml/pages/Image.qml
+++ b/qml/pages/Image.qml
@@ -18,24 +18,13 @@ Page {
 
     SilicaFlickable {
         anchors.fill: parent
-        contentHeight: column.height
 
-        Column {
-            id: column
-
-            width: page.width
-
-            PageHeader { title: model.name }
-
-            Image {
-                id: image
-                visible: status === Image.Ready
-                source: model.url
-                width: parent.width
-                fillMode: Image.PreserveAspectFit
-                sourceSize.width: model.size.width
-                sourceSize.height: model.size.height
-            }
+        AnimatedImage {
+            anchors.fill: parent
+            id: image
+            visible: status === Image.Ready
+            source: model.url
+            fillMode: Image.PreserveAspectFit
         }
     }
 }

--- a/qml/pages/MessageListItem.qml
+++ b/qml/pages/MessageListItem.qml
@@ -88,13 +88,11 @@ ListItem {
                     visible: text.length > 0
                     text: model.title
                 }
-                Image {
+                AnimatedImage {
                     width: parent.width
                     height: model.thumbSize.height
                     fillMode: Image.PreserveAspectFit
                     source: model.thumbUrl
-                    sourceSize.width: model.thumbSize.width
-                    sourceSize.height: model.thumbSize.height
 
                     MouseArea {
                         anchors.fill: parent

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -21,15 +21,5 @@ QNetworkReply* NetworkAccessManager::createRequest(Operation op, const QNetworkR
 }
 
 QString NetworkAccessManager::getToken(QUrl url) {
-    QRegularExpression re("^.*/([A-Z0-9]+)-.*$");
-    QRegularExpressionMatch match = re.match(url.path());
-    if (match.hasMatch()) {
-        const QString team = match.captured(1);
-        SlackClientConfig config(team);
-        const QString token = config.getAccessToken();
-        if (!token.isEmpty()){
-            return config.getAccessToken();
-        }
-    }
     return SlackClientConfig::lastToken();
-}
+g}

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -21,5 +21,15 @@ QNetworkReply* NetworkAccessManager::createRequest(Operation op, const QNetworkR
 }
 
 QString NetworkAccessManager::getToken(QUrl url) {
+    QRegularExpression re("^.*/([A-Z0-9]+)-.*$");
+    QRegularExpressionMatch match = re.match(url.path());
+    if (match.hasMatch()) {
+        const QString team = match.captured(1);
+        SlackClientConfig config(team);
+        const QString token = config.getAccessToken();
+        if (!token.isEmpty()){
+            return config.getAccessToken();
+        }
+    }
     return SlackClientConfig::lastToken();
-g}
+}

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -26,7 +26,10 @@ QString NetworkAccessManager::getToken(QUrl url) {
     if (match.hasMatch()) {
         const QString team = match.captured(1);
         SlackClientConfig config(team);
-        return config.getAccessToken();
+        const QString token = config.getAccessToken();
+        if (!token.isEmpty()){
+            return config.getAccessToken();
+        }
     }
-    return QString();
+    return SlackClientConfig::lastToken();
 }

--- a/src/slackclient.cpp
+++ b/src/slackclient.cpp
@@ -640,6 +640,8 @@ QVariantMap SlackClient::parseGroup(QJsonObject group) {
     QString id = group.value("id").toString();
     QString lastRead = group.value("last_read").toString();
     data.insert("lastRead", lastRead);
+    data.insert("is_starred", group.value("is_starred").toBool());
+    data.insert("is_private", group.value("is_private").toBool());
 
     if (group.value("is_mpim").toBool()) {
         data.insert("type", QVariant("mpim"));
@@ -667,7 +669,6 @@ QVariantMap SlackClient::parseGroup(QJsonObject group) {
         data.insert("type", QVariant("group"));
         data.insert("category", QVariant("channel"));
         data.insert("name", group.value("name").toVariant());
-        data.insert("is_starred", group.value("is_starred").toBool());
         updateChannelUnreadCount(id, lastRead);
     }
 
@@ -702,6 +703,8 @@ QVariantMap SlackClient::parseChat(QJsonObject chat) {
   data.insert("unreadCount", chat.value("unread_count_display").toVariant());
 
   data.insert("is_archived", chat.value("is_archived"));
+  data.insert("is_starred", chat.value("is_starred").toBool());
+  data.insert("is_private", chat.value("is_private").toBool());
 
   return data;
 }

--- a/src/slackclient.cpp
+++ b/src/slackclient.cpp
@@ -667,6 +667,7 @@ QVariantMap SlackClient::parseGroup(QJsonObject group) {
         data.insert("type", QVariant("group"));
         data.insert("category", QVariant("channel"));
         data.insert("name", group.value("name").toVariant());
+        data.insert("is_starred", group.value("is_starred").toBool());
         updateChannelUnreadCount(id, lastRead);
     }
 

--- a/src/slackclient.cpp
+++ b/src/slackclient.cpp
@@ -628,6 +628,8 @@ QVariantMap SlackClient::parseChannel(QJsonObject channel) {
     data.insert("isOpen", channel.value("is_member").toVariant());
     data.insert("lastRead", lastRead);
     data.insert("userId", QVariant());
+    data.insert("is_starred", channel.value("is_starred").toBool());
+    data.insert("is_private", channel.value("is_private").toBool());
 
     updateChannelUnreadCount(id, lastRead);
     return data;

--- a/src/slackclient.cpp
+++ b/src/slackclient.cpp
@@ -122,10 +122,7 @@ void SlackClient::updatePresenceSubscription() {
         if (channel.value("type").toString() == "im" && !channel.value("is_user_deleted").toBool()) {
             userIds.insert(channel.value("userId").toString());
         } else if (channel.value("type").toString() == "mpim" || channel.value("type").toString() == "group") {
-            // TODO: Does presence of mpim and group ever makes sense
-//            for (const auto &member : channel.value("memberIds").toList()) {
-//                userIds.insert(member.toString());
-//            }
+            // skip groups
         } else {
             // skip channels
         }

--- a/src/slackclient.h
+++ b/src/slackclient.h
@@ -42,6 +42,7 @@ public:
     Q_INVOKABLE void setAppActive(bool active);
     Q_INVOKABLE void setActiveWindow(QString windowId);
 
+    Q_INVOKABLE QVariantList getUsers();
     Q_INVOKABLE QVariantList getChannels();
     Q_INVOKABLE QVariant getChannel(const QString& channelId);
 

--- a/src/slackclientconfig.cpp
+++ b/src/slackclientconfig.cpp
@@ -1,8 +1,20 @@
 #include <QDebug>
 #include <QDir>
 #include <QStandardPaths>
+#include <QAtomicPointer>
 
 #include "slackclientconfig.h"
+
+static QAtomicPointer<const SlackClientConfig> s_lastToken{};
+
+QString SlackClientConfig::lastToken() {
+    auto lastToken = s_lastToken.load();
+    if (lastToken) {
+        return lastToken->getAccessToken();
+    } else {
+        return QString();
+    }
+}
 
 SlackClientConfig::SlackClientConfig(const QString &team, QObject *parent)
     : QObject(parent), settings(this) {
@@ -17,6 +29,7 @@ SlackClientConfig::SlackClientConfig(const QString &team, QObject *parent)
 }
 
 QString SlackClientConfig::getAccessToken() const {
+    s_lastToken.store(this);
     return accessToken;
 }
 

--- a/src/slackclientconfig.cpp
+++ b/src/slackclientconfig.cpp
@@ -29,7 +29,9 @@ SlackClientConfig::SlackClientConfig(const QString &team, QObject *parent)
 }
 
 QString SlackClientConfig::getAccessToken() const {
-    s_lastToken.store(this);
+    if (!accessToken.isEmpty()) {
+        s_lastToken.store(this);
+    }
     return accessToken;
 }
 

--- a/src/slackclientconfig.h
+++ b/src/slackclientconfig.h
@@ -15,6 +15,8 @@ class SlackClientConfig : public QObject
 public:
     explicit SlackClientConfig(const QString &team, QObject *parent = 0);
 
+    static QString lastToken();
+
     void clear();
 
     QString getAccessToken() const;

--- a/translations/harbour-sailslack-bg.ts
+++ b/translations/harbour-sailslack-bg.ts
@@ -64,16 +64,21 @@
     </message>
     <message>
         <location filename="../qml/pages/ChannelListView.qml" line="106"/>
-        <source>Unreads</source>
-        <translation>Непрочетени</translation>
+        <source>Unread</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/ChannelListView.qml" line="109"/>
+        <location filename="../qml/pages/ChannelListView.qml" line="108"/>
+        <source>Starred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ChannelListView.qml" line="111"/>
         <source>Channels</source>
         <translation>Канали</translation>
     </message>
     <message>
-        <location filename="../qml/pages/ChannelListView.qml" line="112"/>
+        <location filename="../qml/pages/ChannelListView.qml" line="114"/>
         <source>Direct messages</source>
         <translation>Директни съобщения</translation>
     </message>
@@ -267,17 +272,17 @@ Are you sure you wish to leave?</source>
 <context>
     <name>SlackClient</name>
     <message>
-        <location filename="../src/slackclient.cpp" line="338"/>
+        <location filename="../src/slackclient.cpp" line="335"/>
         <source>in %1 @ %2</source>
         <translation>в %1 @ %2</translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="341"/>
+        <location filename="../src/slackclient.cpp" line="338"/>
         <source>from %1 @ %2</source>
         <translation>от %1 @ %2</translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="344"/>
+        <location filename="../src/slackclient.cpp" line="341"/>
         <source>New message</source>
         <translation>Ново съобщение</translation>
     </message>

--- a/translations/harbour-sailslack-sv.ts
+++ b/translations/harbour-sailslack-sv.ts
@@ -64,16 +64,21 @@
     </message>
     <message>
         <location filename="../qml/pages/ChannelListView.qml" line="106"/>
-        <source>Unreads</source>
-        <translation>Olästa</translation>
+        <source>Unread</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/ChannelListView.qml" line="109"/>
+        <location filename="../qml/pages/ChannelListView.qml" line="108"/>
+        <source>Starred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ChannelListView.qml" line="111"/>
         <source>Channels</source>
         <translation>Kanaler</translation>
     </message>
     <message>
-        <location filename="../qml/pages/ChannelListView.qml" line="112"/>
+        <location filename="../qml/pages/ChannelListView.qml" line="114"/>
         <source>Direct messages</source>
         <translation>Direktmeddelanden</translation>
     </message>
@@ -267,17 +272,17 @@ Vill du verkligen lämna?</translation>
 <context>
     <name>SlackClient</name>
     <message>
-        <location filename="../src/slackclient.cpp" line="338"/>
+        <location filename="../src/slackclient.cpp" line="335"/>
         <source>in %1 @ %2</source>
         <translation>i %1 @ %2</translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="341"/>
+        <location filename="../src/slackclient.cpp" line="338"/>
         <source>from %1 @ %2</source>
         <translation>från %1 @ %2</translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="344"/>
+        <location filename="../src/slackclient.cpp" line="341"/>
         <source>New message</source>
         <translation>Nytt meddelande</translation>
     </message>

--- a/translations/harbour-sailslack.ts
+++ b/translations/harbour-sailslack.ts
@@ -64,16 +64,21 @@
     </message>
     <message>
         <location filename="../qml/pages/ChannelListView.qml" line="106"/>
+        <source>Unread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ChannelListView.qml" line="108"/>
         <source>Starred</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/ChannelListView.qml" line="109"/>
+        <location filename="../qml/pages/ChannelListView.qml" line="111"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/ChannelListView.qml" line="112"/>
+        <location filename="../qml/pages/ChannelListView.qml" line="114"/>
         <source>Direct messages</source>
         <translation type="unfinished"></translation>
     </message>
@@ -262,18 +267,18 @@ Are you sure you wish to leave?</source>
 <context>
     <name>SlackClient</name>
     <message>
-        <location filename="../src/slackclient.cpp" line="337"/>
+        <location filename="../src/slackclient.cpp" line="335"/>
         <source>in %1 @ %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="340"/>
+        <location filename="../src/slackclient.cpp" line="338"/>
         <source>from %1 @ %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="343"/>
-        <source>new messages</source>
+        <location filename="../src/slackclient.cpp" line="341"/>
+        <source>New message</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-sailslack.ts
+++ b/translations/harbour-sailslack.ts
@@ -63,17 +63,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/ChannelListView.qml" line="106"/>
+        <location filename="../qml/pages/ChannelListView.qml" line="105"/>
         <source>Unreads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/ChannelListView.qml" line="109"/>
+        <location filename="../qml/pages/ChannelListView.qml" line="108"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/ChannelListView.qml" line="112"/>
+        <location filename="../qml/pages/ChannelListView.qml" line="111"/>
         <source>Direct messages</source>
         <translation type="unfinished"></translation>
     </message>
@@ -262,18 +262,18 @@ Are you sure you wish to leave?</source>
 <context>
     <name>SlackClient</name>
     <message>
-        <location filename="../src/slackclient.cpp" line="338"/>
+        <location filename="../src/slackclient.cpp" line="339"/>
         <source>in %1 @ %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="341"/>
+        <location filename="../src/slackclient.cpp" line="342"/>
         <source>from %1 @ %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="344"/>
-        <source>New message</source>
+        <location filename="../src/slackclient.cpp" line="345"/>
+        <source>new messages</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-sailslack.ts
+++ b/translations/harbour-sailslack.ts
@@ -64,7 +64,7 @@
     </message>
     <message>
         <location filename="../qml/pages/ChannelListView.qml" line="106"/>
-        <source>Unreads</source>
+        <source>Starred</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/harbour-sailslack.ts
+++ b/translations/harbour-sailslack.ts
@@ -63,17 +63,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/ChannelListView.qml" line="105"/>
+        <location filename="../qml/pages/ChannelListView.qml" line="106"/>
         <source>Unreads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/ChannelListView.qml" line="108"/>
+        <location filename="../qml/pages/ChannelListView.qml" line="109"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/ChannelListView.qml" line="111"/>
+        <location filename="../qml/pages/ChannelListView.qml" line="112"/>
         <source>Direct messages</source>
         <translation type="unfinished"></translation>
     </message>
@@ -262,17 +262,17 @@ Are you sure you wish to leave?</source>
 <context>
     <name>SlackClient</name>
     <message>
-        <location filename="../src/slackclient.cpp" line="339"/>
+        <location filename="../src/slackclient.cpp" line="337"/>
         <source>in %1 @ %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="342"/>
+        <location filename="../src/slackclient.cpp" line="340"/>
         <source>from %1 @ %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/slackclient.cpp" line="345"/>
+        <location filename="../src/slackclient.cpp" line="343"/>
         <source>new messages</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
More metadata about channels allows sorting Starred first. The 'Unread' category is removed but the unread channels/chats are still storted first (so you first have unread Starred, Channels, Direct messages then read Starred, Channels..)

Added animated gif support in image.qml
Also added a 'last used token' for images because I didn't know any better hack to load them.

This PR also includes a skip/ignore of chats with unknown users that were showing up as blank, which I try to load async in the next PR (which will probably include 
a059ae9 and 2337d6e)
Also, the number of presence subscriptions is down to 100, since the previous value was disconnecting me.