### PR TITLE
Users

### DIFF
--- a/qml/pages/UserView.qml
+++ b/qml/pages/UserView.qml
@@ -13,6 +13,15 @@ Page {
         PullDownMenu {
             MenuItem {
                 text: qsTr("Direct Messages")
+                onClicked: {
+                    function navigateTo(chat) {
+                        slackClient.onChannelJoined.disconnect(navigateTo);
+                        pageStack.replace(Qt.resolvedUrl("Channel.qml"), {"slackClient": slackClient, "channelId": chat.id})
+                    }
+
+                    slackClient.onChannelJoined.connect(navigateTo);
+                    slackClient.openUserChat([userId]);
+                }
             }
         }
 

--- a/src/slackclient.cpp
+++ b/src/slackclient.cpp
@@ -834,11 +834,11 @@ void SlackClient::loadConversations(QString cursor) {
       foreach (const QJsonValue &value, data.value("channels").toArray()) {
         QJsonObject channel = value.toObject();
 
-       // Skip private group chats that are closed, we don't want those listed or
-       // counted towards our unread count. If we receive a message in those
-       if (channel.value("is_mpim").toBool() && !channel.value("is_open").toBool()) {
-           continue;
-       }
+        // Skip private group chats that are closed, we don't want those listed or
+        // counted towards our unread count. If we receive a message in those
+        if (channel.value("is_mpim").toBool() && !channel.value("is_open").toBool()) {
+            continue;
+        }
 
         if (channel.value("is_archived").toBool()) {
             continue;

--- a/src/slackclient.h
+++ b/src/slackclient.h
@@ -123,6 +123,7 @@ public slots:
     void leaveChannel(QString channelId);
     void leaveGroup(QString groupId);
     void openChat(QString chatId);
+    void openUserChat(QStringList users);
     void closeChat(QString chatId);
     void postMessage(QString channelId, QString threadId, QString content);
     void postImage(QString channelId, QString imagePath, QString title, QString comment);

--- a/src/slackclient.h
+++ b/src/slackclient.h
@@ -126,6 +126,7 @@ public slots:
     void closeChat(QString chatId);
     void postMessage(QString channelId, QString threadId, QString content);
     void postImage(QString channelId, QString imagePath, QString title, QString comment);
+    void loadUserForChat(QString userId, QJsonObject chat);
     void loadUserInfo(QString userId);
 
     void handleNetworkAccessibleChanged(QNetworkAccessManager::NetworkAccessibility accessible);
@@ -181,6 +182,7 @@ private:
     void updateChannelUnreadCount(QString channelId, QString lastRead);
     void updateImUnreadCount(QString channelId, QString lastRead);
 
+    QVariantMap parseUser(const QJsonObject& user);
     void parseUsers(QJsonObject data);
     void findNewUsers(const QString &message);
 

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -72,7 +72,9 @@ void Storage::setThreadMessages(const QString& threadId, QVariantList messages) 
 }
 
 void Storage::createOrUpdateThread(const QString &threadId, QVariantMap message) {
-    Q_ASSERT(isThreadStarter(message));
+    if (!isThreadStarter(message)) {
+        return;
+    }
     if (!threadMap.contains(threadId)) {
         threadMessageMap.insert(threadId, QVariantList({message}));
         threadMap.insert(threadId, message);

--- a/translations/harbour-sailslack-bg.ts
+++ b/translations/harbour-sailslack-bg.ts
@@ -323,27 +323,27 @@ Are you sure you wish to leave?</source>
         <translation>Директни съобщения</translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="61"/>
+        <location filename="../qml/pages/UserView.qml" line="70"/>
         <source>Display Name</source>
         <translation>Показвано име</translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="68"/>
+        <location filename="../qml/pages/UserView.qml" line="77"/>
         <source>Email</source>
         <translation>Е-поща</translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="75"/>
+        <location filename="../qml/pages/UserView.qml" line="84"/>
         <source>Timezone</source>
         <translation>Часова зона</translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="82"/>
+        <location filename="../qml/pages/UserView.qml" line="91"/>
         <source>Phone</source>
         <translation>Телефон</translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="89"/>
+        <location filename="../qml/pages/UserView.qml" line="98"/>
         <source>Skype</source>
         <translation>Skype</translation>
     </message>

--- a/translations/harbour-sailslack-sv.ts
+++ b/translations/harbour-sailslack-sv.ts
@@ -323,27 +323,27 @@ Vill du verkligen lämna?</translation>
         <translation>Direktmeddelanden</translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="61"/>
+        <location filename="../qml/pages/UserView.qml" line="70"/>
         <source>Display Name</source>
         <translation>Skärmnamn</translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="68"/>
+        <location filename="../qml/pages/UserView.qml" line="77"/>
         <source>Email</source>
         <translation>E-post</translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="75"/>
+        <location filename="../qml/pages/UserView.qml" line="84"/>
         <source>Timezone</source>
         <translation>Tidszon</translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="82"/>
+        <location filename="../qml/pages/UserView.qml" line="91"/>
         <source>Phone</source>
         <translation>Telefon</translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="89"/>
+        <location filename="../qml/pages/UserView.qml" line="98"/>
         <source>Skype</source>
         <translation>Skype</translation>
     </message>

--- a/translations/harbour-sailslack.ts
+++ b/translations/harbour-sailslack.ts
@@ -318,27 +318,27 @@ Are you sure you wish to leave?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="61"/>
+        <location filename="../qml/pages/UserView.qml" line="70"/>
         <source>Display Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="68"/>
+        <location filename="../qml/pages/UserView.qml" line="77"/>
         <source>Email</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="75"/>
+        <location filename="../qml/pages/UserView.qml" line="84"/>
         <source>Timezone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="82"/>
+        <location filename="../qml/pages/UserView.qml" line="91"/>
         <source>Phone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/UserView.qml" line="89"/>
+        <location filename="../qml/pages/UserView.qml" line="98"/>
         <source>Skype</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Lazy load of users that turn out missing when loading `users.conversations`. The idea is that the chat that the user was mentioned in (or direct im) is stored as a user.asyncChat json document until the user is 'resolved' with "users.info" call. Then the user + chat is inserted in the storage.

On a more concrete note, if you don't find a direct message with a user you know you can reach out, you can find a reply of him in any channel and, opening the User info page, you can start writing a direct message to him this way.