### PR TITLE
Mark unread menu option

### DIFF
--- a/qml/pages/Channel.qml
+++ b/qml/pages/Channel.qml
@@ -68,7 +68,6 @@ Page {
         }
         else if (status === PageStatus.Deactivating) {
             slackClient.setActiveWindow("")
-            listView.markLatest()
         }
     }
 }

--- a/qml/pages/MessageListItem.qml
+++ b/qml/pages/MessageListItem.qml
@@ -1,10 +1,15 @@
 import QtQuick 2.1
 import Sailfish.Silica 1.0
+import harbour.sailslack 1.0
 
 ListItem {
     id: item
     contentHeight: column.height + Theme.paddingMedium
     signal openThread(string threadId)
+    signal markUnread(string timestamp)
+
+    property Client slackClient
+    property bool isUnread
 
     menu: ContextMenu {
         MenuItem {
@@ -14,6 +19,13 @@ ListItem {
                 openThread(timestamp)
             }
         }
+        MenuItem {
+            text: qsTr("Mark unread")
+            onClicked: {
+                markUnread(timestamp)
+            }
+        }
+
         MenuItem {
             text: qsTr("User Details")
             onClicked: showUserDetails(user.id)
@@ -52,6 +64,7 @@ ListItem {
             id: contentLabel
             width: parent.width
             font.pixelSize: Theme.fontSizeSmall
+            font.weight: isUnread ? Font.Bold : Font.Normal
             color: textColor
             visible: text.length > 0
             value: content

--- a/qml/pages/MessageListView.qml
+++ b/qml/pages/MessageListView.qml
@@ -96,7 +96,12 @@ SilicaListView {
 
         onMessage: {
             if (messageObject.op === 'replace') {
-                listView.positionViewAtEnd()
+                var unreadIndex = timestampToIndex(channel.lastRead);
+                if (unreadIndex > -1) {
+                    listView.positionViewAtIndex(unreadIndex, ListView.Center)
+                } else {
+                    listView.positionViewAtBeginning()
+                }
                 inputEnabled = true
                 loading = false
                 loadCompleted()

--- a/qml/pages/MessageListView.qml
+++ b/qml/pages/MessageListView.qml
@@ -29,17 +29,8 @@ SilicaListView {
         return -1
     }
 
-    function setLastRead(timestamp, index) {
+    function setLastRead(timestamp) {
         console.log("Setting lastRead to", timestamp)
-        if (typeof index === "number") {
-            // If we're passing an index it means that the _previous_ message needs to be marked.
-            if (index > 0) {
-                var firstUnreadMessage = messageListModel.get(index - 1);
-                timestamp = firstUnreadMessage.timestamp;
-            } else {
-                timestamp = "0000000000.000000"
-            }
-        }
 
         slackClient.markChannel(page.channelId, timestamp)
 
@@ -139,7 +130,12 @@ SilicaListView {
             }
         }
         onMarkUnread: {
-            setLastRead(timestamp, index)
+            if (index > 0) {
+                var firstUnreadMessage = messageListModel.get(index - 1);
+                setLastRead(firstUnreadMessage.timestamp);
+            } else {
+                setLastRead("0000000000.000000")
+            }
         }
     }
 
@@ -204,7 +200,6 @@ SilicaListView {
 
     function markLatest() {
         if (furthestRead != "") {
-            slackClient.markChannel(channel.id, furthestRead)
             setLastRead(furthestRead)
             furthestRead = ""
         }
@@ -248,8 +243,7 @@ SilicaListView {
         var isForThisThread = threadId && thread && threadId === thread.thread_ts;
         var isForThisChannel = !threadId && !thread && channelId === channel.id;
         if (isForThisChannel || isForThisThread) {
-            console.log("handleLoadSuccess", "lastRead", channel.lastRead)
-            setLastRead(channel.lastRead)
+            currentLastRead = channel.lastRead
             hasMoreMessages = hasMore
             loader.sendMessage({
                 op: 'replace',

--- a/translations/harbour-sailslack-bg.ts
+++ b/translations/harbour-sailslack-bg.ts
@@ -317,17 +317,17 @@ Are you sure you wish to leave?</source>
         <translation>Данни на потребителя</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="116"/>
+        <location filename="../qml/pages/MessageListView.qml" line="121"/>
         <source>Thread in #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="151"/>
+        <location filename="../qml/pages/MessageListView.qml" line="156"/>
         <source>Message %1%2</source>
         <translation>Съобщение %1%2</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="151"/>
+        <location filename="../qml/pages/MessageListView.qml" line="156"/>
         <source>Message thread in %1%2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailslack-bg.ts
+++ b/translations/harbour-sailslack-bg.ts
@@ -289,17 +289,22 @@ Are you sure you wish to leave?</source>
 <context>
     <name>MessageListItem</name>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="18"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="23"/>
+        <source>Mark unread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListItem.qml" line="30"/>
         <source>User Details</source>
         <translation>Данни на потребителя</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="67"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="80"/>
         <source>Replies: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="12"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="17"/>
         <source>Reply in thread</source>
         <translation type="unfinished"></translation>
     </message>
@@ -307,22 +312,22 @@ Are you sure you wish to leave?</source>
 <context>
     <name>MessageListView</name>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="39"/>
+        <location filename="../qml/pages/MessageListView.qml" line="73"/>
         <source>User Details</source>
         <translation>Данни на потребителя</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="82"/>
+        <location filename="../qml/pages/MessageListView.qml" line="116"/>
         <source>Thread in #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="112"/>
+        <location filename="../qml/pages/MessageListView.qml" line="151"/>
         <source>Message %1%2</source>
         <translation>Съобщение %1%2</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="112"/>
+        <location filename="../qml/pages/MessageListView.qml" line="151"/>
         <source>Message thread in %1%2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailslack-bg.ts
+++ b/translations/harbour-sailslack-bg.ts
@@ -312,22 +312,22 @@ Are you sure you wish to leave?</source>
 <context>
     <name>MessageListView</name>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="73"/>
+        <location filename="../qml/pages/MessageListView.qml" line="64"/>
         <source>User Details</source>
         <translation>Данни на потребителя</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="121"/>
+        <location filename="../qml/pages/MessageListView.qml" line="112"/>
         <source>Thread in #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="156"/>
+        <location filename="../qml/pages/MessageListView.qml" line="152"/>
         <source>Message %1%2</source>
         <translation>Съобщение %1%2</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="156"/>
+        <location filename="../qml/pages/MessageListView.qml" line="152"/>
         <source>Message thread in %1%2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailslack-sv.ts
+++ b/translations/harbour-sailslack-sv.ts
@@ -317,17 +317,17 @@ Vill du verkligen lämna?</translation>
         <translation>Användarinformation</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="116"/>
+        <location filename="../qml/pages/MessageListView.qml" line="121"/>
         <source>Thread in #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="151"/>
+        <location filename="../qml/pages/MessageListView.qml" line="156"/>
         <source>Message %1%2</source>
         <translation>Meddelande %1%2</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="151"/>
+        <location filename="../qml/pages/MessageListView.qml" line="156"/>
         <source>Message thread in %1%2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailslack-sv.ts
+++ b/translations/harbour-sailslack-sv.ts
@@ -312,22 +312,22 @@ Vill du verkligen lämna?</translation>
 <context>
     <name>MessageListView</name>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="73"/>
+        <location filename="../qml/pages/MessageListView.qml" line="64"/>
         <source>User Details</source>
         <translation>Användarinformation</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="121"/>
+        <location filename="../qml/pages/MessageListView.qml" line="112"/>
         <source>Thread in #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="156"/>
+        <location filename="../qml/pages/MessageListView.qml" line="152"/>
         <source>Message %1%2</source>
         <translation>Meddelande %1%2</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="156"/>
+        <location filename="../qml/pages/MessageListView.qml" line="152"/>
         <source>Message thread in %1%2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailslack-sv.ts
+++ b/translations/harbour-sailslack-sv.ts
@@ -289,17 +289,22 @@ Vill du verkligen lämna?</translation>
 <context>
     <name>MessageListItem</name>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="18"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="23"/>
+        <source>Mark unread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListItem.qml" line="30"/>
         <source>User Details</source>
         <translation>Användarinformation</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="67"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="80"/>
         <source>Replies: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="12"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="17"/>
         <source>Reply in thread</source>
         <translation type="unfinished"></translation>
     </message>
@@ -307,22 +312,22 @@ Vill du verkligen lämna?</translation>
 <context>
     <name>MessageListView</name>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="39"/>
+        <location filename="../qml/pages/MessageListView.qml" line="73"/>
         <source>User Details</source>
         <translation>Användarinformation</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="82"/>
+        <location filename="../qml/pages/MessageListView.qml" line="116"/>
         <source>Thread in #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="112"/>
+        <location filename="../qml/pages/MessageListView.qml" line="151"/>
         <source>Message %1%2</source>
         <translation>Meddelande %1%2</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="112"/>
+        <location filename="../qml/pages/MessageListView.qml" line="151"/>
         <source>Message thread in %1%2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailslack.ts
+++ b/translations/harbour-sailslack.ts
@@ -307,22 +307,22 @@ Are you sure you wish to leave?</source>
 <context>
     <name>MessageListView</name>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="73"/>
+        <location filename="../qml/pages/MessageListView.qml" line="64"/>
         <source>User Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="121"/>
+        <location filename="../qml/pages/MessageListView.qml" line="112"/>
         <source>Thread in #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="156"/>
+        <location filename="../qml/pages/MessageListView.qml" line="152"/>
         <source>Message %1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="156"/>
+        <location filename="../qml/pages/MessageListView.qml" line="152"/>
         <source>Message thread in %1%2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailslack.ts
+++ b/translations/harbour-sailslack.ts
@@ -284,17 +284,22 @@ Are you sure you wish to leave?</source>
 <context>
     <name>MessageListItem</name>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="18"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="23"/>
+        <source>Mark unread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MessageListItem.qml" line="30"/>
         <source>User Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="67"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="80"/>
         <source>Replies: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListItem.qml" line="12"/>
+        <location filename="../qml/pages/MessageListItem.qml" line="17"/>
         <source>Reply in thread</source>
         <translation type="unfinished"></translation>
     </message>
@@ -302,22 +307,22 @@ Are you sure you wish to leave?</source>
 <context>
     <name>MessageListView</name>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="39"/>
+        <location filename="../qml/pages/MessageListView.qml" line="73"/>
         <source>User Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="82"/>
+        <location filename="../qml/pages/MessageListView.qml" line="116"/>
         <source>Thread in #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="112"/>
+        <location filename="../qml/pages/MessageListView.qml" line="151"/>
         <source>Message %1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="112"/>
+        <location filename="../qml/pages/MessageListView.qml" line="151"/>
         <source>Message thread in %1%2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailslack.ts
+++ b/translations/harbour-sailslack.ts
@@ -312,17 +312,17 @@ Are you sure you wish to leave?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="116"/>
+        <location filename="../qml/pages/MessageListView.qml" line="121"/>
         <source>Thread in #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="151"/>
+        <location filename="../qml/pages/MessageListView.qml" line="156"/>
         <source>Message %1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MessageListView.qml" line="151"/>
+        <location filename="../qml/pages/MessageListView.qml" line="156"/>
         <source>Message thread in %1%2</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
#28 

- changes the display of unread messages to bold
- removes the marking of a channel as read when leaving
- keeps track of the last read timestamp, either at load time or at 'Mark unread' click
- if a message is marked unread, the _previous_ one is set as last read.
- If you use Mark unread the timer is reset so you have 5 seconds until it is read again

Possible improvements:
- the timer could mark the timestamp of only messages in view