### PR TITLE
Don't scroll up if unread index not found, it happens

### DIFF
--- a/qml/pages/MessageListView.qml
+++ b/qml/pages/MessageListView.qml
@@ -90,8 +90,6 @@ SilicaListView {
                 var unreadIndex = timestampToIndex(channel.lastRead);
                 if (unreadIndex > -1) {
                     listView.positionViewAtIndex(unreadIndex, ListView.Center)
-                } else {
-                    listView.positionViewAtBeginning()
                 }
                 inputEnabled = true
                 loading = false


### PR DESCRIPTION
E.g. in case of thread unread messages (or may be other cases) the view should not scroll up. Doing nothing seems the better way.