### PR TITLE
[Feature/storage] Cleanup of previous threads fix. Fix longstanding sort order

### DIFF
--- a/src/models/channelmessagesmodel.cpp
+++ b/src/models/channelmessagesmodel.cpp
@@ -12,7 +12,8 @@ Q_LOGGING_CATEGORY(logModel, "harbour-sailslack.ChannelMessageModel")
 
 ChannelMessagesModel::ChannelMessagesModel(QObject *parent)
     : QAbstractProxyModel{parent}
-{}
+{
+}
 
 QVariant ChannelMessagesModel::get(int index) const {
     if (index < 0 || index >= rowCount()) {
@@ -118,7 +119,7 @@ int ChannelMessagesModel::columnCount(const QModelIndex &parent) const
         return 0;
     }
 
-    return sourceModel()->rowCount(mSourceRootIndex);
+    return sourceModel()->columnCount(mSourceRootIndex);
 }
 
 bool ChannelMessagesModel::hasChildren(const QModelIndex &parent) const

--- a/src/models/messagemodel.cpp
+++ b/src/models/messagemodel.cpp
@@ -212,8 +212,7 @@ void MessageModel::doInsertMessage(Node *parentNode, const QVariantMap &message,
     if (parentNode->type == EntityType::Message) {
         parentNode = parentNode->parent;
     }
-    Q_ASSERT(parentNode->type == EntityType::Channel ||
-             parentNode->type == EntityType::Message);
+    Q_ASSERT(parentNode->type == EntityType::Channel);
     const auto channelId = parentNode->data.value(fieldChannelId).toString();
     const auto messageId = message[fieldMessageId].toString();
     mMessageLookup.insert(channelId + messageId, nodePtr);
@@ -328,7 +327,7 @@ void MessageModel::removeChannelMessage(const ChannelID &channelId, const Messag
     }
 }
 
-void MessageModel::setThreadMessages(const ChannelID &channelId, const ThreadID &threadId, QVariantList &messages)
+void MessageModel::setThreadMessages(const ChannelID &channelId, const ThreadID &threadId, const QVariantList &messages)
 {
     if (!messages.size()) return;
     auto *tlNode = mMessageLookup.value(channelId + threadId);
@@ -339,12 +338,6 @@ void MessageModel::setThreadMessages(const ChannelID &channelId, const ThreadID 
 
     const auto tlIndex = nodeIndex(tlNode);
     clearThreadMessages(tlNode, tlIndex);
-
-    if (messages.first().toMap()[fieldMessageId].toString() == threadId) {
-        qDebug() << "Found a thread leader in thread message, size was " << messages.size();
-        messages.removeFirst();
-    }
-    qDebug() << "Message size is now " << messages.size();
 
     beginInsertRows(tlIndex, 0, messages.size() - 1);
     tlNode->children.reserve(messages.size());

--- a/src/models/messagemodel.h
+++ b/src/models/messagemodel.h
@@ -127,7 +127,7 @@ public:
     /*! \param[in] channelId ID of the channel the thread belongs to
      * \param[in] threadID ID of the thread leader message
      * \param[in] messages The thread replies, excluding the thread-leader message. */
-    void setThreadMessages(const ChannelID &channelId, const ThreadID &threadId, const QVariantList &messages);
+    void setThreadMessages(const ChannelID &channelId, const ThreadID &threadId, QVariantList &messages);
 
     //! Notifies the model that a thread has been opened in the GUI.
     /*! Ensures that the messages in the opened thread are not evicted from the cache

--- a/src/models/messagemodel.h
+++ b/src/models/messagemodel.h
@@ -127,7 +127,7 @@ public:
     /*! \param[in] channelId ID of the channel the thread belongs to
      * \param[in] threadID ID of the thread leader message
      * \param[in] messages The thread replies, excluding the thread-leader message. */
-    void setThreadMessages(const ChannelID &channelId, const ThreadID &threadId, QVariantList &messages);
+    void setThreadMessages(const ChannelID &channelId, const ThreadID &threadId, const QVariantList &messages);
 
     //! Notifies the model that a thread has been opened in the GUI.
     /*! Ensures that the messages in the opened thread are not evicted from the cache

--- a/src/slackclient.cpp
+++ b/src/slackclient.cpp
@@ -1281,7 +1281,8 @@ QVariantMap SlackClient::getMessageData(const QJsonObject message) {
     QString timePart = timeParts.value(0);
     QString indexPart = timeParts.value(1);
 
-    qlonglong timestamp = timePart.toLongLong() * multiplier + indexPart.toLongLong();
+    // The ts parts are like 1672172273.123456 (seconds) - we transform them to 1672172273123 (milliseconds)
+    qlonglong timestamp = timePart.toLongLong() * multiplier + indexPart.toLongLong() / multiplier;
     QDateTime time = QDateTime::fromMSecsSinceEpoch(timestamp);
 
     QVariantMap data;

--- a/src/slackclient.cpp
+++ b/src/slackclient.cpp
@@ -1131,6 +1131,10 @@ void SlackClient::handleLoadMessagesReply() {
     if (!channelId.isEmpty() && threadId.isEmpty()) {
         messageModel.setChannelMessages(channelId, messages);
     } else if (!threadId.isEmpty()) {
+        // Exclude the thread leader.
+        if (messages.first().toMap()["id"].toString() == threadId) {
+            messages.removeFirst();
+        }
         messageModel.setThreadMessages(channelId, threadId, messages);
     }
 


### PR DESCRIPTION
The first commit is going to be cherry-picked in master too.

The rest is a cleaner attempt at last time where I removed the 'thread leader' from the list, plus making an Assert tolerant to messages having parent messages, plus fixing another assert / crash by changing the caller's `messages` list. The last's approach is debatable, so I'm open to suggestions.