### PR TITLE
Fix longstanding milliseconds bug

### DIFF
--- a/src/slackclient.cpp
+++ b/src/slackclient.cpp
@@ -1269,7 +1269,8 @@ QVariantMap SlackClient::getMessageData(const QJsonObject message) {
     QString timePart = timeParts.value(0);
     QString indexPart = timeParts.value(1);
 
-    qlonglong timestamp = timePart.toLongLong() * multiplier + indexPart.toLongLong();
+    // The ts parts are like 1672172273.123456 (seconds) - we transform them to 1672172273123 (milliseconds)
+    qlonglong timestamp = timePart.toLongLong() * multiplier + indexPart.toLongLong() / multiplier;
     QDateTime time = QDateTime::fromMSecsSinceEpoch(timestamp);
 
     QVariantMap data;


### PR DESCRIPTION
The timestamp seconds to milliseconds conversion was adding the part after the . (which is a 6 figure number) and which was polluting the seconds part by adding as much as 16 minutes (max 999 seconds) to the timestamp.

Since Qt is not having a microsecond datetime, for now I just use the first 3 figures after the dot, and drop the rest.

(Previous text)
(not tested yet on master, only on feature/storage branch, I have a dbus build problem but pretty sure this is 5+years bug in that code)

I ended up running manually into src `qdbusxml2cpp -c SailslackAdaptor -a sailslack_adaptor.h:sailslack_adaptor.cpp harbour.sailslack.xml`.

Tested on master now too